### PR TITLE
chores(depsync): update github.com/cryptellation/runtime to v1.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cryptellation/candlesticks v1.1.0
 	github.com/cryptellation/dbmigrator v1.0.1
 	github.com/cryptellation/health v1.1.1
-	github.com/cryptellation/runtime v1.7.0
+	github.com/cryptellation/runtime v1.8.1
 	github.com/cryptellation/version v1.1.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/cryptellation/runtime v1.5.0 h1:bOQRYVBwFg8r+ciRLmYm9ATsmy18T5cXg+Ohj
 github.com/cryptellation/runtime v1.5.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
 github.com/cryptellation/runtime v1.7.0 h1:8qCi8nBAsjQyF1a2makR1JIHuI9jSSJBWGS1NRoRfWE=
 github.com/cryptellation/runtime v1.7.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
+github.com/cryptellation/runtime v1.8.1 h1:59uH/Ce4B76JvlP8kkNtQjCkVzIifvYIkL3HXqjkaOM=
+github.com/cryptellation/runtime v1.8.1/go.mod h1:dYFBN+zeroKiaSb7QgnOUB4leN9SqQXz7FK46x7PNJk=
 github.com/cryptellation/ticks v1.0.1 h1:ejJqbfBPY72SaS+aQlGAfBEc4lDWY1zf44GLt1wQFeE=
 github.com/cryptellation/ticks v1.0.1/go.mod h1:sJ8aUr7QDX3YmlCrEHl9clvepTgzjaV6k8e1kdFIuqw=
 github.com/cryptellation/ticks v1.0.3 h1:i4ZMyFT4N1+IO/kKBvTnl3eq6qKIw3ezHpBvBvSQoWA=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/runtime** to version **v1.8.1**.

### Changes
- Updated dependency: `github.com/cryptellation/runtime`
- New version: `v1.8.1`

This update was automatically generated by DepSync.