### PR TITLE
chores(depsync): update github.com/cryptellation/ticks to v1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 )
 
 require (
-	github.com/cryptellation/ticks v1.2.1 // indirect
+	github.com/cryptellation/ticks v1.3.1 // indirect
 	github.com/cryptellation/timeseries v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/cryptellation/ticks v1.2.0 h1:VK6818yT1B239kL45aXsWPeWJHhNGJOAmKXHTS9
 github.com/cryptellation/ticks v1.2.0/go.mod h1:tTMMu1U1e1I1J9Dp73KGh411TWrKcYmB4xORNJNPHtE=
 github.com/cryptellation/ticks v1.2.1 h1:onvm8kmEyBxK5ELWrzUqqCd8+6BT3LhPfBmUP11J6Vo=
 github.com/cryptellation/ticks v1.2.1/go.mod h1:tTMMu1U1e1I1J9Dp73KGh411TWrKcYmB4xORNJNPHtE=
+github.com/cryptellation/ticks v1.3.1 h1:iMVSQIyWy+xIj9237FB4WwvP4QgweCub5dpNEoVXOtk=
+github.com/cryptellation/ticks v1.3.1/go.mod h1:8Gyw4D7WsKJR4mTQS3UyLjlG83Bx/Q1VGatsj6HNLyg=
 github.com/cryptellation/timeseries v1.0.2 h1:Vdrp4AZ7yfBlyANtU7vT9SptBQs8vdjXyjRnkX0C7iA=
 github.com/cryptellation/timeseries v1.0.2/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
 github.com/cryptellation/timeseries v1.1.0 h1:S5xFLGukQg+k22+L5151Na95+WjhhDKMK0hBkxfJYgo=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/ticks** to version **v1.3.1**.

### Changes
- Updated dependency: `github.com/cryptellation/ticks`
- New version: `v1.3.1`

This update was automatically generated by DepSync.