### PR TITLE
chores(depsync): update github.com/cryptellation/health to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/cryptellation/candlesticks v1.1.0
 	github.com/cryptellation/dbmigrator v1.1.0
-	github.com/cryptellation/health v1.1.1
+	github.com/cryptellation/health v1.2.0
 	github.com/cryptellation/runtime v1.8.1
 	github.com/cryptellation/version v1.4.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/cryptellation/health v1.0.1 h1:wZp/y4z8CbSVKUWCL/+8TdPPAPWLScUrJl/YBJ
 github.com/cryptellation/health v1.0.1/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
 github.com/cryptellation/health v1.1.1 h1:LerBgSsMME5P6WGqG40uKoZI7QZ5ISpRGTJ1Toe4lWo=
 github.com/cryptellation/health v1.1.1/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
+github.com/cryptellation/health v1.2.0 h1:0j4k2VGRSgOTOX2ehrbcMQC9vkY5MLBuM0AaFRABSD8=
+github.com/cryptellation/health v1.2.0/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
 github.com/cryptellation/runtime v1.4.0 h1:ZLccWKe2zW62W5gMhkoJVOUhrZXWJy02QGxH70sgxgo=
 github.com/cryptellation/runtime v1.4.0/go.mod h1:9fCU3JXp50lIT/RQBIfyP/4yjSKfWAJSLPq6pGDJU2E=
 github.com/cryptellation/runtime v1.4.3 h1:iPH6fDILaSL+cX4YWjb0qika+G8pyjlv1qLhVt5at5o=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/health** to version **v1.2.0**.

### Changes
- Updated dependency: `github.com/cryptellation/health`
- New version: `v1.2.0`

This update was automatically generated by DepSync.